### PR TITLE
Allow Ruby 3.0

### DIFF
--- a/password_blacklist.gemspec
+++ b/password_blacklist.gemspec
@@ -28,9 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0.0'
 
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'simplecov', '~> 0.12.0'
+  spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'rubocop', '~> 0.49.1'
-  spec.add_development_dependency 'coveralls', '~> 0.8.18'
+  spec.add_development_dependency 'coveralls', '~> 0.8.23'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.4'
   spec.add_development_dependency 'benchmark-ips', '~> 2.7.2'
 end

--- a/password_blacklist.gemspec
+++ b/password_blacklist.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.platform      = Gem::Platform::RUBY
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 12.0.0'


### PR DESCRIPTION
The gemspec specifies ruby version as '~> 2.0', which means that the gem doesn't install on Ruby 3.0 and above. However, the code works perfectly fine in 3.0, so relaxing the version requirement to '>= 2.0' allows it to be used going forward as well.

A couple of gem versions have been updated as well, to remove the fixnum deprecation warning from Ruby 2.4.