### PR TITLE
Add Ruby 3.2 to Github Actions test matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,7 @@ jobs:
           - 2.7
           - '3.0'
           - 3.1
+          - 3.2
           - head
     steps:
     - name: 🛒 Checkout Code


### PR DESCRIPTION
- Add Ruby 3.2 to Github Actions test matrix
